### PR TITLE
feat: Add wine bridge support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Binaries folder 
+binaries/

--- a/Dalamud.RichPresence/Configuration/RichPresenceConfig.cs
+++ b/Dalamud.RichPresence/Configuration/RichPresenceConfig.cs
@@ -30,5 +30,9 @@ namespace Dalamud.RichPresence.Configuration
         public bool ShowParty = true;
 
         public bool ShowAfk = true;
+
+        // RPC Bridge for Wine.
+        public bool RPCBridgeEnabled = true;
+        public string RPCBridgePath = $@"{RichPresencePlugin.DalamudPluginInterface.AssemblyLocation.Directory}\binaries\WineLinuxRPCBridge.exe";
     }
 }

--- a/Dalamud.RichPresence/Dalamud.RichPresence.csproj
+++ b/Dalamud.RichPresence/Dalamud.RichPresence.csproj
@@ -1,19 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <AssemblyName>Dalamud.RichPresence</AssemblyName>
-        <TargetFramework>net5.0-windows</TargetFramework>
+        <TargetFramework>net6.0-windows</TargetFramework>
         <PlatformTarget>x64</PlatformTarget>
         <Platforms>x64;AnyCPU</Platforms>
-        <LangVersion>9.0</LangVersion>
+        <LangVersion>latest</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
         <NoWarn>IDE0003</NoWarn>
-        <AssemblyVersion>2.0.0.5</AssemblyVersion>
+        <AssemblyVersion>2.0.2.0</AssemblyVersion>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     </PropertyGroup>
     <PropertyGroup Label="Documentation">
-        <DocumentationFile/>
+        <DocumentationFile />
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <PropertyGroup Label="Build">
@@ -32,9 +33,10 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="DalamudPackager" Version="2.1.7"/>
-        <PackageReference GeneratePathProperty="true" Include="DiscordRichPresence" Version="1.0.175"/>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
+        <PackageReference Include="DalamudPackager" Version="2.1.8" />
+        <PackageReference GeneratePathProperty="true" Include="DiscordRichPresence" Version="1.1.1.14" />
+		<PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+		<PackageReference Include="NCalcSync" Version="3.5.0" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -45,11 +47,33 @@
         <DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'">
+      <DalamudLibPath>$(DALAMUD_HOME)/</DalamudLibPath>
+      <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    </PropertyGroup>
+
+    <Target Name="DownloadWineDiscordIpcBridge" BeforeTargets="Build">
+        <DownloadFile
+            SourceUrl="https://github.com/0e4ef622/wine-discord-ipc-bridge/releases/latest/download/winediscordipcbridge.exe"
+            DestinationFolder="$(ProjectDir)binaries" 
+            DestinationFileName="WineLinuxRPCBridge.exe" 
+            Condition="!Exists('$(ProjectDir)binaries\WineLinuxRPCBridge.exe')"
+        />
+        <DownloadFile
+            SourceUrl="https://raw.githubusercontent.com/0e4ef622/wine-discord-ipc-bridge/master/LICENSE"
+            DestinationFolder="$(ProjectDir)binaries"
+            DestinationFileName="WineLinuxRPCBridgeLicense.txt"
+            Condition="!Exists('$(ProjectDir)binaries\WineLinuxRPCBridgeLicense.txt')"
+        />
+    </Target>
+
     <ItemGroup>
-        <PackageReference Include="DalamudPackager" Version="2.1.7"/>
-        <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0"/>
-        <PackageReference Include="NCalcSync" Version="2.0.0"/>
-        <PackageReference Include="XivCommon" Version="4.0.0-alpha.2"/>
+        <None Update="binaries/**">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+
+    <ItemGroup>
         <Reference Include="FFXIVClientStructs">
             <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
             <Private>false</Private>
@@ -81,16 +105,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Content Remove="Resources/loc/*.json"/>
+        <Content Remove="Resources/loc/*.json" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="Dalamud.RichPresence.json">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
-        <None Include="$(PkgDiscordRichPresence)\lib\net35\DiscordRPC.dll">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
         <None Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " Include="icon.png">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/Dalamud.RichPresence/Dalamud.RichPresence.json
+++ b/Dalamud.RichPresence/Dalamud.RichPresence.json
@@ -5,6 +5,7 @@
   "Punchline": "Show your zone, job, level, name, and world in your Discord status",
   "InternalName": "Dalamud.RichPresence",
   "ApplicableVersion": "any",
-  "Changelog": "* Added party grouping support, will show people you group with on Discord if they also use the plugin\n* Now shows AFK status by default, can be disabled\n* Now shows queue position if Waitingway is installed",
-  "Tags": [ "Discord" ]
+  "RepoUrl": "https://github.com/goaaats/Dalamud.RichPresence",
+  "Changelog": "Wine bridge support on Linux and Mac (@Blooym)",
+  "Tags": ["Discord"]
 }

--- a/Dalamud.RichPresence/Interface/RichPresenceConfigWindow.cs
+++ b/Dalamud.RichPresence/Interface/RichPresenceConfigWindow.cs
@@ -1,11 +1,10 @@
 using System.Numerics;
 using Dalamud.Interface.Colors;
 using ImGuiNET;
-
 using Dalamud.Logging;
-
 using Dalamud.RichPresence.Configuration;
 using Dalamud.RichPresence.Models;
+using RichPresencePlugin.Utils;
 
 namespace Dalamud.RichPresence.Interface
 {
@@ -26,7 +25,7 @@ namespace Dalamud.RichPresence.Interface
                 return;
             }
 
-            ImGui.SetNextWindowSize(new Vector2(750, 520));
+            ImGui.SetNextWindowSize(new Vector2(750, 570));
             var imGuiReady = ImGui.Begin(
                 RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceConfiguration", LocalizationLanguage.Plugin),
                 ref IsOpen,
@@ -39,7 +38,7 @@ namespace Dalamud.RichPresence.Interface
                 ImGui.Text(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresencePreface2", LocalizationLanguage.Plugin));
                 ImGui.Separator();
 
-                ImGui.BeginChild("scrolling", new Vector2(0, 400), true, ImGuiWindowFlags.HorizontalScrollbar);
+                ImGui.BeginChild("scrolling", new Vector2(0, 440), true, ImGuiWindowFlags.HorizontalScrollbar);
 
                 ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(1, 3));
 
@@ -59,6 +58,14 @@ namespace Dalamud.RichPresence.Interface
                 ImGui.Separator();
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceShowParty", LocalizationLanguage.Plugin), ref RichPresenceConfig.ShowParty);
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceShowAFK", LocalizationLanguage.Plugin), ref RichPresenceConfig.ShowAfk);
+                ImGui.Separator();
+                if (CommonUtil.IsOnLinuxOrWine())
+                {
+                    ImGui.TextWrapped(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceRPCBridgeDesc", LocalizationLanguage.Plugin));
+                    ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceRPCBridgeEnabled", LocalizationLanguage.Plugin), ref RichPresenceConfig.RPCBridgeEnabled);
+                    ImGui.InputTextWithHint(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceRPCBridgePath", LocalizationLanguage.Plugin), RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceRPCBridgePathHint", LocalizationLanguage.Plugin), ref RichPresenceConfig.RPCBridgePath, 1024);
+                }
+
 
                 ImGui.PopStyleVar();
 

--- a/Dalamud.RichPresence/Managers/DiscordPresenceManager.cs
+++ b/Dalamud.RichPresence/Managers/DiscordPresenceManager.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-
-using RichPresencePlugin.Utils;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Dalamud.Logging;
 using DiscordRPC;
 using DiscordRPC.Logging;
-using System.Diagnostics;
-using System.Threading.Tasks;
-using System.IO;
-using Dalamud.Logging;
+using RichPresencePlugin.Utils;
 
 namespace Dalamud.RichPresence.Managers
 {
@@ -90,26 +89,14 @@ namespace Dalamud.RichPresence.Managers
                     return;
                 }
 
-                // Start a new bridge process.
-                ProcessStartInfo startInfo = new ProcessStartInfo()
+                PluginLog.LogInformation($"Starting Wine bridge process: {bridgeExecutablePath}");
+                this.bridgeProcess = Process.Start(new ProcessStartInfo
                 {
                     FileName = bridgeExecutablePath,
                     UseShellExecute = false,
                     CreateNoWindow = true,
-                };
-                Process.Start(startInfo);
-                PluginLog.LogInformation($"Starting Wine bridge process: {bridgeExecutablePath} {startInfo.Arguments}");
-
-                // Setup a task that waits for the bridge to be active, and bind it to bridgeProcess.
-                new Task(() =>
-                {
-                    var bridge = Process.GetProcessesByName(bridgeExecutableName);
-                    while (bridge.Length == 0)
-                    {
-                        bridge = Process.GetProcessesByName(bridgeExecutableName);
-                    }
-                    bridgeProcess = bridge[0];
-                }).Start();
+                });
+                PluginLog.LogInformation($"Started Wine bridge process, PID: {bridgeProcess.Id}");
             }
             catch (Exception e)
             {

--- a/Dalamud.RichPresence/Managers/DiscordPresenceManager.cs
+++ b/Dalamud.RichPresence/Managers/DiscordPresenceManager.cs
@@ -1,7 +1,12 @@
 ﻿using System;
 
+using RichPresencePlugin.Utils;
 using DiscordRPC;
 using DiscordRPC.Logging;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using System.IO;
+using Dalamud.Logging;
 
 namespace Dalamud.RichPresence.Managers
 {
@@ -9,10 +14,16 @@ namespace Dalamud.RichPresence.Managers
     {
         private const string DISCORD_CLIENT_ID = "478143453536976896";
         private DiscordRpcClient RpcClient;
+        private Process bridgeProcess;
 
         internal DiscordPresenceManager()
         {
             this.CreateClient();
+
+            if (CommonUtil.IsOnLinuxOrWine() && RichPresencePlugin.RichPresenceConfig.RPCBridgeEnabled)
+            {
+                this.StartWineRPCBridge();
+            }
         }
 
         private void CreateClient()
@@ -63,9 +74,56 @@ namespace Dalamud.RichPresence.Managers
             RpcClient.UpdateStartTime(newStartTime);
         }
 
+        public void StartWineRPCBridge()
+        {
+            try
+            {
+                var bridgeExecutableName = new DirectoryInfo(RichPresencePlugin.RichPresenceConfig.RPCBridgePath).Name;
+                var bridgeExecutablePath = RichPresencePlugin.RichPresenceConfig.RPCBridgePath;
+
+                // Check if bridge is already running.
+                var wineBridge = Process.GetProcessesByName(bridgeExecutableName);
+                if (wineBridge.Length > 0)
+                {
+                    PluginLog.LogInformation($"Found existing Wine bridge process, PID: {wineBridge[0].Id}, not starting a new one.");
+                    bridgeProcess = wineBridge[0];
+                    return;
+                }
+
+                // Start a new bridge process.
+                ProcessStartInfo startInfo = new ProcessStartInfo()
+                {
+                    FileName = bridgeExecutablePath,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                };
+                Process.Start(startInfo);
+                PluginLog.LogInformation($"Starting Wine bridge process: {bridgeExecutablePath} {startInfo.Arguments}");
+
+                // Setup a task that waits for the bridge to be active, and bind it to bridgeProcess.
+                new Task(() =>
+                {
+                    var bridge = Process.GetProcessesByName(bridgeExecutableName);
+                    while (bridge.Length == 0)
+                    {
+                        bridge = Process.GetProcessesByName(bridgeExecutableName);
+                    }
+                    bridgeProcess = bridge[0];
+                }).Start();
+            }
+            catch (Exception e)
+            {
+                PluginLog.LogError(e, "Error starting Wine bridge process.");
+            }
+        }
+
         public void Dispose()
         {
             RpcClient?.Dispose();
+
+            PluginLog.LogInformation("Killing Wine bridge process.");
+            bridgeProcess?.Kill();
+
         }
     }
 }

--- a/Dalamud.RichPresence/Resources/loc/dalamud_richpresence_en.json
+++ b/Dalamud.RichPresence/Resources/loc/dalamud_richpresence_en.json
@@ -103,20 +103,20 @@
     "message": "Show away from keyboard status",
     "description": "Dalamud.RichPresence.Configuration.ShowAFK"
   },
-  "DalamudRichPresenceInLoginQueue": {
-    "message": "In Login Queue (#{0})",
-    "description": "Dalamud.RichPresence.Details.InLoginQueue"
+  "DalamudRichPresenceRPCBridgeEnabled": {
+    "message": "Enable RPC Bridge",
+    "description": "Dalamud.RichPresence.Configuration.RPCBridgeEnabled"
   },
-  "DalamudRichPresenceQueueEstimate": {
-    "message": "ETA: {0:h':'mm':'ss}",
-    "description": "Dalamud.RichPresence.Details.QueueEstimate"
+  "DalamudRichPresenceRPCBridgePath": {
+    "message": "RPC Bridge Path",
+    "description": "Dalamud.RichPresence.Configuration.RPCBridgePath"
   },
-  "DalamudRichPresenceShowLoginQueuePosition": {
-    "message": "Show login queue position",
-    "description": "Dalamud.RichPresence.Configuration.ShowLoginQueuePosition"
+  "DalamudRichPresenceRPCBridgePathHint": {
+    "message": "Path to the RPC Bridge executable",
+    "description": "Dalamud.RichPresence.Configuration.RPCBridgePathHint"
   },
-  "DalamudRichPresenceShowLoginQueuePositionDetail": {
-    "message": "This integration requires the Waitingway plugin to be installed.",
-    "description": "Dalamud.RichPresence.Configuration.ShowLoginQueuePositionDetail"
+  "DalamudRichPresenceRPCBridgeDesc": {
+    "message": "The wine bridge executable to use to forward the RPC data to Discord. Settings apply on next plugin load.",
+    "description": "Dalamud.RichPresence.Configuration.RPCBridgeDesc"
   }
 }

--- a/Dalamud.RichPresence/Utils/Common.cs
+++ b/Dalamud.RichPresence/Utils/Common.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace RichPresencePlugin.Utils
+{
+    internal static class CommonUtil
+    {
+        internal static bool IsOnLinuxOrWine()
+        {
+            var wineOnLinux = Environment.GetEnvironmentVariable("XL_WINEONLINUX");
+            var wineOnMac = Environment.GetEnvironmentVariable("XL_WINEONMAC");
+            return wineOnLinux?.ToLower() == "true" || wineOnLinux?.ToLower() == "1" || wineOnMac?.ToLower() == "true" || wineOnMac?.ToLower() == "1";
+        }
+    }
+}

--- a/Dalamud.RichPresence/packages.lock.json
+++ b/Dalamud.RichPresence/packages.lock.json
@@ -1,18 +1,18 @@
 {
   "version": 1,
   "dependencies": {
-    "net5.0-windows7.0": {
+    "net6.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[2.1.7, )",
-        "resolved": "2.1.7",
-        "contentHash": "jnZ/sdInyn07ycuWI+pPOtP/xE3v+c4+jYJfDt36FWnBF9NKqkpzfviJtPl/jGLgbaCmFIXu+Yid0N8GvdKefg=="
+        "requested": "[2.1.8, )",
+        "resolved": "2.1.8",
+        "contentHash": "YqagNXs9InxmqkXzq7kLveImxnodkBEicAhydMXVp7dFjC7xb76U6zGgAax4/BWIWfZeWzr5DJyQSev31kj81A=="
       },
       "DiscordRichPresence": {
         "type": "Direct",
-        "requested": "[1.0.175, )",
-        "resolved": "1.0.175",
-        "contentHash": "qSWobPTbvHh9gOoBYT8C8eUhKtVdBI/WvW7GY9lNMEtsZIpL6nxCvYJwjsGL3dqlEAGY5k0vdq+wnuDLVBSV2w==",
+        "requested": "[1.1.1.14, )",
+        "resolved": "1.1.1.14",
+        "contentHash": "9DAETjebo1EK4eD0t3NUlg7jltXszIyVKBzY3xBw5bgRkxoexbX1ZcJGK8Pfzq+LV7Ybc/GUGNGmH6LU75mkNw==",
         "dependencies": {
           "Microsoft.Win32.Registry": "4.5.0",
           "Newtonsoft.Json": "12.0.2"
@@ -30,18 +30,12 @@
       },
       "NCalcSync": {
         "type": "Direct",
-        "requested": "[2.0.0, )",
-        "resolved": "2.0.0",
-        "contentHash": "kTGfqfxTGFtu5PYJpYQFPA/+uWeSFdsfBRt5FHBObWF0jNcPhQgfGT53nyXyrl+o4A492HDyBN62tGkE4pC+cQ==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "IdBB+LeWaL9h+rZ+TW4V/WUy4a19CUtelYTLLKtPIIxbmeLc9xPPcGul9CPs2Gl6glGX9lvB3iXhNA+9EUucGA==",
         "dependencies": {
           "Antlr3.Runtime": "3.5.1"
         }
-      },
-      "Newtonsoft.Json": {
-        "type": "Direct",
-        "requested": "[13.0.1, )",
-        "resolved": "13.0.1",
-        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -51,12 +45,6 @@
         "dependencies": {
           "StyleCop.Analyzers.Unstable": "1.2.0.333"
         }
-      },
-      "XivCommon": {
-        "type": "Direct",
-        "requested": "[4.0.0-alpha.2, )",
-        "resolved": "4.0.0-alpha.2",
-        "contentHash": "ugdPMg3LKEWDY3DvdcfctjDW8QTaRnXfKJ9gFlY8036LVQ6guOG3grG65EIkIKIhbyg3b2E2ZWOhgeLYEcS00w=="
       },
       "Antlr3.Runtime": {
         "type": "Transitive",
@@ -136,6 +124,11 @@
           "System.Xml.ReaderWriter": "4.0.11",
           "System.Xml.XDocument": "4.0.11"
         }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "12.0.2",
+        "contentHash": "rTK0s2EKlfHsQsH6Yx2smvcTCeyoDNgCW7FEYyV01drPlh2T243PR2DiDXqtC5N4GDm4Ma/lkxfW5a/4793vbA=="
       },
       "runtime.native.System": {
         "type": "Transitive",


### PR DESCRIPTION
Adds support for specifying a custom Wine RPC Bridge for Linux or OSX systems. Ships https://github.com/0e4ef622/wine-discord-ipc-bridge by default, installed inside of the csproj file. This has been tested and should work on all Linux systems, however MacOS users may need to specify a different executable.

I've also included #15 alongside this to make sure the Plugin would build.

I've attempted to stick to the conventions used by this codebase where possible. Let me know if you want any changes made.